### PR TITLE
New output FITS file naming scheme

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-master-v4.5
+master-v5.0

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-master-v5.0
+master-v4.5

--- a/notes/fix_pre46_filenames.py
+++ b/notes/fix_pre46_filenames.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Rename outout FITS lightcurve files from old to new naming scheme.
+
+.. codeauthor:: Rasmus Handberg <rasmush@phys.au.dk>
+"""
+
+import logging
+import argparse
+import os.path
+import re
+from tqdm import tqdm
+import sys
+if sys.path[0] != os.path.abspath(os.path.join(os.path.dirname(__file__), '..')):
+	sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from photometry import TaskManager
+from photometry.utilities import TqdmLoggingHandler
+
+#--------------------------------------------------------------------------------------------------
+if __name__ == '__main__':
+
+	# Parse command line arguments:
+	parser = argparse.ArgumentParser(description='Rename output FITS lightcurve files to new naming scheme.')
+	parser.add_argument('-d', '--debug', help='Print debug messages.', action='store_true')
+	parser.add_argument('-q', '--quiet', help='Only report warnings and errors.', action='store_true')
+	parser.add_argument('input_folder', type='str', help='Input directory')
+	args = parser.parse_args()
+
+	# Set logging level:
+	logging_level = logging.INFO
+	if args.quiet:
+		logging_level = logging.WARNING
+	elif args.debug:
+		logging_level = logging.DEBUG
+
+	# Setup logging:
+	formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+	console = TqdmLoggingHandler()
+	console.setFormatter(formatter)
+	logger = logging.getLogger(__name__)
+	logger.addHandler(console)
+	logger.setLevel(logging_level)
+
+	inp = args.input_folder
+	input_folder = os.path.abspath(os.path.dirname(inp))
+	logger.info("Renaming files in %s", input_folder)
+	if not os.path.isdir(input_folder):
+		parser.error("Input folder does not exist")
+
+	tqdm_settings = {'disable': not logger.isEnabledFor(logging.INFO)}
+
+	regex_old = re.compile(r'^tess(\d+)-s(\d+)-c(\d+)-dr(\d+)-v(\d+)-tasoc_lc\.fits\.gz$')
+	regex_new = re.compile(r'^tess(\d+)-s(\d+)-[1-4]-[1-4]-c(\d+)-dr(\d+)-v(\d+)-tasoc_lc\.fits\.gz$')
+
+	with TaskManager(input_folder) as tm:
+
+		tm.cursor.execute("SELECT todolist.priority,lightcurve,camera,ccd FROM todolist INNER JOIN diagnostics ON todolist.priority=diagnostics.priority WHERE lightcurve IS NOT NULL;")
+		results = tm.cursor.fetchall()
+
+		try:
+			for k, row in enumerate(tqdm(results, **tqdm_settings)):
+
+				fpath = os.path.join(input_folder, row['lightcurve'])
+				if not os.path.isfile(fpath):
+					logger.error("File not found: '%s'", row['lightcurve'])
+					continue
+
+				bname = os.path.basename(fpath)
+				m = regex_old.match(bname)
+				if m:
+					# The new filename:
+					filename = 'tess{starid:011d}-s{sector:03d}-{camera:d}-{ccd:d}-c{cadence:04d}-dr{datarel:02d}-v{version:02d}-tasoc_lc.fits.gz'.format(
+						starid=int(m.group(1)),
+						sector=int(m.group(2)),
+						camera=row['camera'],
+						ccd=row['ccd'],
+						cadence=int(m.group(3)),
+						datarel=int(m.group(4)),
+						version=int(m.group(5))
+					)
+
+					newpath = os.path.join(os.path.dirname(fpath), filename)
+					relpath = os.path.relpath(newpath, input_folder)
+
+					os.rename(fpath, newpath)
+					tm.cursor.execute("UPDATE diagnostics SET lightcurve=? WHERE priority=?;", [relpath, row['priority']])
+
+					if k % 1000 == 0:
+						tm.conn.commit()
+
+				else:
+					m = regex_new.match(bname)
+					if not m:
+						logger.error("Does not match old naming scheme")
+
+			tm.conn.commit()
+		except (KeyboardInterrupt, SystemExit):
+			tm.conn.commit()
+		except:
+			tm.conn.rollback()
+			raise
+
+	print("Done")

--- a/photometry/BasePhotometry.py
+++ b/photometry/BasePhotometry.py
@@ -1643,9 +1643,11 @@ class BasePhotometry(object):
 			hdus.append(wm)
 
 		# File name to save the lightcurve under:
-		filename = 'tess{starid:011d}-s{sector:02d}-c{cadence:04d}-dr{datarel:02d}-v{version:02d}-tasoc_lc.fits.gz'.format(
+		filename = 'tess{starid:011d}-s{sector:03d}-{camera:d}-{ccd:d}-c{cadence:04d}-dr{datarel:02d}-v{version:02d}-tasoc_lc.fits.gz'.format(
 			starid=self.starid,
 			sector=self.sector,
+			camera=self.camera,
+			ccd=self.ccd,
 			cadence=cadence,
 			datarel=self.data_rel,
 			version=version

--- a/photometry/taskmanager.py
+++ b/photometry/taskmanager.py
@@ -124,7 +124,7 @@ class TaskManager(object):
 			self.conn.commit()
 		if 'method_used' not in existing_columns:
 			# Since this one is NOT NULL, we have to do some magic to fill out the
-			# new column after creation, by finding ketwords in other columns.
+			# new column after creation, by finding keywords in other columns.
 			# This can be a pretty slow process, but it only has to be done once.
 			self.logger.debug("Adding method_used column to diagnostics")
 			self.cursor.execute("ALTER TABLE diagnostics ADD COLUMN method_used TEXT NOT NULL DEFAULT 'aperture';")

--- a/photometry/taskmanager.py
+++ b/photometry/taskmanager.py
@@ -338,7 +338,12 @@ class TaskManager(object):
 				# We never want to return a lightcurve for a secondary target over
 				# a primary target, so we are going to mark this one as SKIPPED.
 				primary_tpf_target_starid = int(result['datasource'][4:])
-				self.cursor.execute("SELECT priority FROM todolist WHERE starid=? AND datasource='tpf' AND sector=?;", (primary_tpf_target_starid, result['sector']))
+				self.cursor.execute("SELECT priority FROM todolist WHERE starid=? AND datasource='tpf' AND sector=? AND camera=? AND ccd=?;", (
+					primary_tpf_target_starid,
+					result['sector'],
+					result['camera'],
+					result['ccd']
+				))
 				primary_tpf_target_priority = self.cursor.fetchone()
 				# Mark the current star as SKIPPED and that it was caused by the primary:
 				self.logger.info("Changing status to SKIPPED for priority %s because it overlaps with primary target TIC %d", result['priority'], primary_tpf_target_starid)
@@ -350,7 +355,7 @@ class TaskManager(object):
 					))
 				else:
 					self.logger.warning("Could not find primary TPF target (TIC %d) for priority=%d", primary_tpf_target_starid, result['priority'])
-					error_msg.append("Could not find primary TPF target (TIC %d)" % primary_tpf_target_starid)
+					error_msg.append("TargetNotFoundError: Could not find primary TPF target (TIC %d)" % primary_tpf_target_starid)
 			else:
 				# Create unique list of starids to be masked as skipped:
 				skip_starids = ','.join([str(starid) for starid in skip_targets])
@@ -362,7 +367,11 @@ class TaskManager(object):
 				else:
 					skip_datasources = "'" + result['datasource'] + "'"
 
-				self.cursor.execute("SELECT priority,tmag FROM todolist WHERE starid IN (" + skip_starids + ") AND datasource IN (" + skip_datasources + ") AND sector=?;", (result['sector'],))
+				self.cursor.execute("SELECT priority,tmag FROM todolist WHERE starid IN (" + skip_starids + ") AND datasource IN (" + skip_datasources + ") AND sector=? AND camera=? AND ccd=?;", (
+					result['sector'],
+					result['camera'],
+					result['ccd']
+				))
 				skip_rows = self.cursor.fetchall()
 				if len(skip_rows) > 0:
 					skip_tmags = np.array([row['tmag'] for row in skip_rows])

--- a/photometry/taskmanager.py
+++ b/photometry/taskmanager.py
@@ -45,6 +45,7 @@ class TaskManager(object):
 		self.overwrite = overwrite
 		self.summary_file = summary
 		self.summary_interval = summary_interval
+		self.summary_counter = 0
 
 		if os.path.isdir(todo_file):
 			todo_file = os.path.join(todo_file, 'todo.sqlite')
@@ -60,7 +61,8 @@ class TaskManager(object):
 		console = logging.StreamHandler()
 		console.setFormatter(formatter)
 		self.logger = logging.getLogger(__name__)
-		self.logger.addHandler(console)
+		if not self.logger.hasHandlers():
+			self.logger.addHandler(console)
 		self.logger.setLevel(logging.INFO)
 
 		# Load the SQLite file:
@@ -462,7 +464,9 @@ class TaskManager(object):
 		self.conn.commit()
 
 		# Write summary file:
-		if self.summary_file and self.summary['tasks_run'] % self.summary_interval == 0:
+		self.summary_counter += 1
+		if self.summary_file and self.summary_counter % self.summary_interval == 0:
+			self.summary_counter = 0
 			self.write_summary()
 
 	#----------------------------------------------------------------------------------------------
@@ -472,5 +476,5 @@ class TaskManager(object):
 			try:
 				with open(self.summary_file, 'w') as fid:
 					json.dump(self.summary, fid)
-			except: # noqa: E722
+			except: # noqa: E722, pragma: no cover
 				self.logger.exception("Could not write summary file")

--- a/photometry/todolist.py
+++ b/photometry/todolist.py
@@ -580,7 +580,7 @@ def make_todo(input_folder=None, cameras=None, ccds=None, overwrite=False,
 			))
 
 		conn.commit()
-		cursor.execute("CREATE INDEX starid_datasource_idx ON todolist (starid, datasource);") # FIXME: Should be "UNIQUE", but something is weird in ETE-6?!
+		cursor.execute("CREATE UNIQUE INDEX unique_target_idx ON todolist (starid, datasource, sector, camera, ccd);")
 		cursor.execute("CREATE INDEX status_idx ON todolist (status);")
 		cursor.execute("CREATE INDEX starid_idx ON todolist (starid);")
 		conn.commit()

--- a/photometry/todolist.py
+++ b/photometry/todolist.py
@@ -547,7 +547,7 @@ def make_todo(input_folder=None, cameras=None, ccds=None, overwrite=False,
 		# Create TODO-list table:
 		cursor.execute("""CREATE TABLE todolist (
 			priority INTEGER PRIMARY KEY ASC NOT NULL,
-			starid BIGINT NOT NULL,
+			starid INTEGER NOT NULL,
 			sector INTEGER NOT NULL,
 			datasource TEXT NOT NULL DEFAULT 'ffi',
 			camera INTEGER NOT NULL,

--- a/photometry/utilities.py
+++ b/photometry/utilities.py
@@ -690,7 +690,7 @@ def sqlite_drop_column(conn, table, col):
 	index_sql = [row[1] for row in index]
 
 	# Warn if any index exist with the column to be removed:
-	regex_index = re.compile(r'^CREATE( UNIQUE)? INDEX (.+) ON ' + re.escape(table) + '\s*\((.+)\).*$', re.IGNORECASE)
+	regex_index = re.compile(r'^CREATE( UNIQUE)? INDEX (.+) ON ' + re.escape(table) + r'\s*\((.+)\).*$', re.IGNORECASE)
 	for sql in index_sql:
 		m = regex_index.match(sql)
 		if not m:
@@ -721,7 +721,7 @@ def sqlite_drop_column(conn, table, col):
 			cursor.execute(sql)
 
 		conn.commit()
-	except:
+	except: # noqa: E722, pragma: nocover
 		conn.rollback()
 		raise
 	finally:

--- a/photometry/utilities.py
+++ b/photometry/utilities.py
@@ -694,7 +694,7 @@ def sqlite_drop_column(conn, table, col):
 	for sql in index_sql:
 		m = regex_index.match(sql)
 		if not m:
-			raise Exception("COULD NOT UNDERSTAND SQL")
+			raise Exception("COULD NOT UNDERSTAND SQL") # pragma: no cover
 		index_columns = [i.strip() for i in m.group(3).split(',')]
 		if col in index_columns:
 			raise Exception("Column is used in INDEX %s." % m.group(2))
@@ -721,7 +721,7 @@ def sqlite_drop_column(conn, table, col):
 			cursor.execute(sql)
 
 		conn.commit()
-	except: # noqa: E722, pragma: nocover
+	except: # noqa: E722, pragma: no cover
 		conn.rollback()
 		raise
 	finally:

--- a/tests/test_taskmanager.py
+++ b/tests/test_taskmanager.py
@@ -211,7 +211,7 @@ def test_taskmanager_summary(PRIVATE_TODO_FILE):
 			row = tm.cursor.fetchone()
 			print(dict(row))
 			assert row['priority'] == task['priority']
-			assert 'starid' not in row # It should no longer be there (after version 4.6)
+			assert 'starid' not in row # It should no longer be there (after version 5.0)
 			assert row['elaptime'] == 3.14
 			assert row['method_used'] == 'aperture'
 
@@ -257,7 +257,7 @@ def test_taskmanager_summary(PRIVATE_TODO_FILE):
 			row = tm.cursor.fetchone()
 			print(dict(row))
 			assert row['priority'] == task['priority']
-			assert 'starid' not in row # It should no longer be there (after version 4.6)
+			assert 'starid' not in row # It should no longer be there (after version 5.0)
 			assert row['elaptime'] == 6.14
 			assert row['method_used'] == 'halo'
 			assert row['errors'] == "dummy error 1\ndummy error 2"

--- a/tests/test_taskmanager.py
+++ b/tests/test_taskmanager.py
@@ -390,8 +390,6 @@ def test_taskmanager_skip_targets(PRIVATE_TODO_FILE):
 		assert row['priority'] == task['priority']
 		assert row['skipped_by'] == row3['priority']
 
-	assert False
-
 #--------------------------------------------------------------------------------------------------
 if __name__ == '__main__':
 	pytest.main([__file__])

--- a/tests/test_taskmanager.py
+++ b/tests/test_taskmanager.py
@@ -282,7 +282,7 @@ def test_taskmanager_summary(PRIVATE_TODO_FILE):
 			assert j['mean_worker_waittime'] == 1.1
 
 #--------------------------------------------------------------------------------------------------
-def test_taskmanager_skip_targets(PRIVATE_TODO_FILE):
+def test_taskmanager_skip_targets1(PRIVATE_TODO_FILE):
 	with TaskManager(PRIVATE_TODO_FILE, overwrite=True, cleanup=True) as tm:
 
 		# Start task with a random task:
@@ -333,13 +333,9 @@ def test_taskmanager_skip_targets(PRIVATE_TODO_FILE):
 		assert row['priority'] == row2['priority']
 		assert row['skipped_by'] == task['priority']
 
-		#================================================================
-		# RESET THE TODO-FILE:
-		tm.cursor.execute("UPDATE todolist SET status=NULL;")
-		tm.cursor.execute("DELETE FROM diagnostics;")
-		tm.cursor.execute("DELETE FROM photometry_skipped;")
-		tm.conn.commit()
-		#================================================================
+#--------------------------------------------------------------------------------------------------
+def test_taskmanager_skip_targets2(PRIVATE_TODO_FILE):
+	with TaskManager(PRIVATE_TODO_FILE) as tm:
 
 		# Start task with a random task:
 		task = tm.get_task(starid=261522674, datasource='ffi') # Tmag = 14.574

--- a/tests/test_taskmanager.py
+++ b/tests/test_taskmanager.py
@@ -391,5 +391,96 @@ def test_taskmanager_skip_targets(PRIVATE_TODO_FILE):
 		assert row['skipped_by'] == row3['priority']
 
 #--------------------------------------------------------------------------------------------------
+def test_taskmanager_skip_targets_secondary1(PRIVATE_TODO_FILE):
+	with TaskManager(PRIVATE_TODO_FILE) as tm:
+
+		# Start task with a random task:
+		task = tm.get_task(starid=261522674, datasource='ffi') # Tmag = 14.574
+		print(task)
+
+		# Make a fake result we can save;
+		tm.start_task(task['priority'])
+		result = task.copy()
+		result['datasource'] = 'tpf:267211065'
+		result['status'] = STATUS.OK
+		result['time'] = 6.14
+		result['worker_wait_time'] = 2.0
+		result['method_used'] = 'aperture'
+		result['details'] = {
+			'skip_targets': [267211065] # Tmag = 2.216
+		}
+
+		tm.save_result(result)
+
+		# For a secondary target with the primary in skipped_targets, the secondary should
+		# end up marked as skipped with a warning in the errors column:
+		tm.cursor.execute("SELECT * FROM todolist LEFT JOIN diagnostics ON todolist.priority=diagnostics.priority WHERE todolist.priority=?;", [task['priority']])
+		row = tm.cursor.fetchall()
+		assert len(row) == 1
+		row = row[0]
+		print(dict(row))
+		assert row['priority'] == task['priority']
+		assert row['starid'] == task['starid']
+		assert row['sector'] == task['sector']
+		assert row['camera'] == task['camera']
+		assert row['ccd'] == task['ccd']
+		assert row['elaptime'] == 6.14
+		assert row['method_used'] == 'aperture'
+		assert row['status'] == STATUS.SKIPPED.value
+
+		# There should now be exactly one entry in the photometry_skipped table:
+		tm.cursor.execute("SELECT * FROM photometry_skipped;")
+		row = tm.cursor.fetchall()
+		assert len(row) == 1
+		row = row[0]
+		print(dict(row))
+		assert row['priority'] == task['priority']
+		assert row['skipped_by'] == 1
+
+#--------------------------------------------------------------------------------------------------
+def test_taskmanager_skip_targets_secondary2(PRIVATE_TODO_FILE):
+	with TaskManager(PRIVATE_TODO_FILE) as tm:
+
+		# Start task with a random task:
+		task = tm.get_task(starid=261522674, datasource='ffi') # Tmag = 14.574
+		print(task)
+
+		# Make a fake result we can save;
+		tm.start_task(task['priority'])
+		result = task.copy()
+		result['datasource'] = 'tpf:999999999'
+		result['status'] = STATUS.OK
+		result['time'] = 6.14
+		result['worker_wait_time'] = 2.0
+		result['method_used'] = 'aperture'
+		result['details'] = {
+			'skip_targets': [999999999] # Tmag = 2.216
+		}
+
+		tm.save_result(result)
+
+		# For a secondary target with the primary in skipped_targets, the secondary should
+		# end up marked as skipped with a warning in the errors column:
+		tm.cursor.execute("SELECT * FROM todolist LEFT JOIN diagnostics ON todolist.priority=diagnostics.priority WHERE todolist.priority=?;", [task['priority']])
+		row = tm.cursor.fetchall()
+		assert len(row) == 1
+		row = row[0]
+		print(dict(row))
+		assert row['priority'] == task['priority']
+		assert row['starid'] == task['starid']
+		assert row['sector'] == task['sector']
+		assert row['camera'] == task['camera']
+		assert row['ccd'] == task['ccd']
+		assert row['elaptime'] == 6.14
+		assert row['method_used'] == 'aperture'
+		assert row['status'] == STATUS.SKIPPED.value
+		assert 'TargetNotFoundError: ' in row['errors']
+
+		# The photometry_skipped table should still be empty because of the warning:
+		tm.cursor.execute("SELECT * FROM photometry_skipped;")
+		row = tm.cursor.fetchall()
+		assert len(row) == 0
+
+#--------------------------------------------------------------------------------------------------
 if __name__ == '__main__':
 	pytest.main([__file__])

--- a/tests/test_taskmanager.py
+++ b/tests/test_taskmanager.py
@@ -149,10 +149,12 @@ def test_taskmanager_no_more_tasks(PRIVATE_TODO_FILE):
 def test_taskmanager_summary(PRIVATE_TODO_FILE):
 	with tempfile.TemporaryDirectory() as tmpdir:
 		summary_file = os.path.join(tmpdir, 'summary.json')
-		with TaskManager(PRIVATE_TODO_FILE, overwrite=True, summary=summary_file) as tm:
+		with TaskManager(PRIVATE_TODO_FILE, overwrite=True, summary=summary_file, summary_interval=2) as tm:
 			# Load the summary file:
 			with open(summary_file, 'r') as fid:
 				j = json.load(fid)
+
+			assert tm.summary_counter == 0  # Counter should start at zero
 
 			# Everytning should be really empty:
 			print(j)
@@ -201,6 +203,7 @@ def test_taskmanager_summary(PRIVATE_TODO_FILE):
 
 			# Save the result:
 			tm.save_result(result)
+			assert tm.summary_counter == 1 # We saved once, so counter should have gone up one
 			tm.write_summary()
 
 			# Check that the diagnostics were updated:
@@ -246,6 +249,7 @@ def test_taskmanager_summary(PRIVATE_TODO_FILE):
 
 			# Save the result:
 			tm.save_result(result)
+			assert tm.summary_counter == 0 # We saved again, so summary_counter should be zero
 			tm.write_summary()
 
 			# Check that the diagnostics were updated:
@@ -276,6 +280,117 @@ def test_taskmanager_summary(PRIVATE_TODO_FILE):
 			assert j['last_error'] == "dummy error 1\ndummy error 2"
 			assert j['mean_elaptime'] == 3.44
 			assert j['mean_worker_waittime'] == 1.1
+
+#--------------------------------------------------------------------------------------------------
+def test_taskmanager_skip_targets(PRIVATE_TODO_FILE):
+	with TaskManager(PRIVATE_TODO_FILE, overwrite=True, cleanup=True) as tm:
+
+		# Start task with a random task:
+		task = tm.get_task(starid=267211065, datasource='ffi') # Tmag = 2.216
+		#task = tm.get_task(starid=261522674) # Tmag = 14.574
+		print(task)
+
+		# Make a fake result we can save:
+		tm.start_task(task['priority'])
+		result = task.copy()
+		result['status'] = STATUS.OK
+		result['time'] = 6.14
+		result['worker_wait_time'] = 2.0
+		result['method_used'] = 'aperture'
+		result['details'] = {
+			'skip_targets': [261522674] # Tmag = 14.574
+		}
+
+		tm.save_result(result)
+
+		tm.cursor.execute("SELECT * FROM todolist LEFT JOIN diagnostics ON todolist.priority=diagnostics.priority WHERE todolist.priority=?;", [task['priority']])
+		row = tm.cursor.fetchall()
+		assert len(row) == 1
+		row = row[0]
+		print(dict(row))
+		assert row['priority'] == task['priority']
+		assert row['starid'] == task['starid']
+		assert row['sector'] == task['sector']
+		assert row['camera'] == task['camera']
+		assert row['ccd'] == task['ccd']
+		assert row['elaptime'] == 6.14
+		assert row['method_used'] == 'aperture'
+		assert row['status'] == STATUS.OK.value
+
+		tm.cursor.execute("SELECT * FROM todolist LEFT JOIN diagnostics ON todolist.priority=diagnostics.priority WHERE starid=261522674 AND datasource='ffi';")
+		row2 = tm.cursor.fetchall()
+		assert len(row2) == 1
+		row2 = row2[0]
+		print(dict(row2))
+		assert row2['status'] == STATUS.SKIPPED.value
+
+		# There should now be exactly one entry in the photometry_skipped table:
+		tm.cursor.execute("SELECT * FROM photometry_skipped;")
+		row = tm.cursor.fetchall()
+		assert len(row) == 1
+		row = row[0]
+		print(dict(row))
+		assert row['priority'] == row2['priority']
+		assert row['skipped_by'] == task['priority']
+
+		#================================================================
+		# RESET THE TODO-FILE:
+		tm.cursor.execute("UPDATE todolist SET status=NULL;")
+		tm.cursor.execute("DELETE FROM diagnostics;")
+		tm.cursor.execute("DELETE FROM photometry_skipped;")
+		tm.conn.commit()
+		#================================================================
+
+		# Start task with a random task:
+		task = tm.get_task(starid=261522674, datasource='ffi') # Tmag = 14.574
+		print(task)
+
+		# Make a fake result we can save;
+		tm.start_task(task['priority'])
+		result = task.copy()
+		result['status'] = STATUS.OK
+		result['time'] = 6.14
+		result['worker_wait_time'] = 2.0
+		result['method_used'] = 'aperture'
+		result['details'] = {
+			'skip_targets': [267211065] # Tmag = 2.216
+		}
+
+		tm.save_result(result)
+
+		# This time the processed target (the faint one) should end up marked as SKIPPED:
+		tm.cursor.execute("SELECT * FROM todolist LEFT JOIN diagnostics ON todolist.priority=diagnostics.priority WHERE todolist.priority=?;", [task['priority']])
+		row = tm.cursor.fetchall()
+		assert len(row) == 1
+		row = row[0]
+		print(dict(row))
+		assert row['priority'] == task['priority']
+		assert row['starid'] == task['starid']
+		assert row['sector'] == task['sector']
+		assert row['camera'] == task['camera']
+		assert row['ccd'] == task['ccd']
+		assert row['elaptime'] == 6.14
+		assert row['method_used'] == 'aperture'
+		assert row['status'] == STATUS.SKIPPED.value
+
+		# And the bright target should not have STATUS set, so it can be processed later on:
+		tm.cursor.execute("SELECT * FROM todolist LEFT JOIN diagnostics ON todolist.priority=diagnostics.priority WHERE starid=267211065 AND datasource='ffi';")
+		row3 = tm.cursor.fetchall()
+		assert len(row3) == 1
+		row3 = row3[0]
+		print(dict(row3))
+		assert row3['status'] is None
+
+		# There should now be exactly one entry in the photometry_skipped table:
+		tm.cursor.execute("SELECT * FROM photometry_skipped;")
+		row = tm.cursor.fetchall()
+		assert len(row) == 1
+		row = row[0]
+		print(dict(row))
+		assert row['priority'] == task['priority']
+		assert row['skipped_by'] == row3['priority']
+
+	assert False
 
 #--------------------------------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/tests/test_taskmanager.py
+++ b/tests/test_taskmanager.py
@@ -208,7 +208,7 @@ def test_taskmanager_summary(PRIVATE_TODO_FILE):
 			row = tm.cursor.fetchone()
 			print(dict(row))
 			assert row['priority'] == task['priority']
-			assert row['starid'] == task['starid']
+			assert 'starid' not in row # It should no longer be there (after version 4.6)
 			assert row['elaptime'] == 3.14
 			assert row['method_used'] == 'aperture'
 
@@ -253,7 +253,7 @@ def test_taskmanager_summary(PRIVATE_TODO_FILE):
 			row = tm.cursor.fetchone()
 			print(dict(row))
 			assert row['priority'] == task['priority']
-			assert row['starid'] == task['starid']
+			assert 'starid' not in row # It should no longer be there (after version 4.6)
 			assert row['elaptime'] == 6.14
 			assert row['method_used'] == 'halo'
 			assert row['errors'] == "dummy error 1\ndummy error 2"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -157,6 +157,21 @@ def test_rms_timescale():
 	print(rms)
 	np.testing.assert_allclose(rms, 0)
 
+	# Time with infinity should give ValueError:
+	time[1] = np.Inf
+	with pytest.raises(ValueError):
+		u.rms_timescale(time, flux)
+
+	# Time with negative infinity should give ValueError:
+	time[1] = np.NINF
+	with pytest.raises(ValueError):
+		u.rms_timescale(time, flux)
+
+	# All timestamps being the same should give ValueError:
+	time[:] = 1.2
+	with pytest.raises(ValueError):
+		u.rms_timescale(time, flux)
+
 #--------------------------------------------------------------------------------------------------
 def test_find_nearest():
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -238,7 +238,7 @@ def test_sqlite_drop_column(factory, foreign_keys):
 			cursor.execute("INSERT INTO tbl VALUES (%d,RANDOM(),RANDOM(),RANDOM(),RANDOM());" % k)
 		cursor.execute("CREATE UNIQUE INDEX col_a_idx ON tbl (col_a);")
 		cursor.execute("CREATE INDEX col_c_idx ON tbl (col_c);")
-		cursor.execute("CREATE INDEX col_de_idx ON tbl (col_d, col_e);")
+		cursor.execute("CREATE\t INDEX  col_de_idx ON tbl (col_d, col_e);") # with strange whitespace
 		conn.commit()
 
 		# Check names of columns before we remove anything:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -247,7 +247,7 @@ def test_sqlite_drop_column(factory, foreign_keys):
 		assert s == set(['col_a', 'col_b', 'col_c', 'col_d', 'col_e'])
 
 		# Remove col_b:
-		u.sqlite_drop_column(conn, 'tbl', 'col_b');
+		u.sqlite_drop_column(conn, 'tbl', 'col_b')
 
 		# Check names of columns after we removed col_b:
 		cursor.execute("PRAGMA table_info(tbl);")
@@ -264,18 +264,18 @@ def test_sqlite_drop_column(factory, foreign_keys):
 
 		# Wrong table or column name should give a ValueError:
 		with pytest.raises(ValueError):
-			u.sqlite_drop_column(conn, 'tbl_wrong', 'col_e');
+			u.sqlite_drop_column(conn, 'tbl_wrong', 'col_e')
 
 		with pytest.raises(ValueError):
-			u.sqlite_drop_column(conn, 'tbl', 'col_wrong');
+			u.sqlite_drop_column(conn, 'tbl', 'col_wrong')
 
 		# Attempting to drop a column associated with an index should
 		# cause an Exception:
 		with pytest.raises(Exception):
-			u.sqlite_drop_column(conn, 'tbl', 'col_c');
+			u.sqlite_drop_column(conn, 'tbl', 'col_c')
 
 		with pytest.raises(Exception):
-			u.sqlite_drop_column(conn, 'tbl', 'col_e');
+			u.sqlite_drop_column(conn, 'tbl', 'col_e')
 
 #--------------------------------------------------------------------------------------------------
 if __name__ == '__main__':


### PR DESCRIPTION
This PR will change the structure of the file-names output by the photometry to include the TESS camera and CCD in the name.

The issues addressed by this PR are:
1. Avoid duplicate filenames in cases of targets that are observed in overlapping cameras.
2. Enforce unique lightcurves in TODO-file (related to 1).
3. Ensure that naming scheme would work for 8+ years of TESS operation (sectors > 99).
4. Remove duplicate information in TODO-file (starid).
5. Fix issues with targets in overlapping regions potentially marking targets on the other CCD as SKIPPED.